### PR TITLE
config.sh: blacklist_effects: Add missing /

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -104,7 +104,7 @@ set_permissions() {
 # This function blacklists modules/effects known to mess with V4A
 blacklist_effects() {
   EFFECT_LIST="
-    system/priv-app/MusicFX
+    /system/priv-app/MusicFX
     /system/priv-app/AudioFX
     /system/app/DiracAudioControlService
     /system/app/DiracManager"


### PR DESCRIPTION
Fixes V4A no driver found issues on ROMs with MusicFX (such as AEX)